### PR TITLE
Add in check for spares in use

### DIFF
--- a/check_zpools.sh
+++ b/check_zpools.sh
@@ -3,6 +3,7 @@
 #########################################################################
 # Script:     check_zpools.sh
 # Purpose:    Nagios plugin to monitor status of zfs pool
+# Doc:        http://www.claudiokuenzler.com/monitoring-plugins/check_zpools.php
 # Licence:    GNU General Public Licence (GPL) v2 http://www.gnu.org/
 #########################################################################
 # This program is free software; you can redistribute it and/or

--- a/check_zpools.sh
+++ b/check_zpools.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
+
 #########################################################################
 # Script:     check_zpools.sh
 # Purpose:    Nagios plugin to monitor status of zfs pool
-# Doc:        http://www.claudiokuenzler.com/monitoring-plugins/check_zpools.php
 # Licence:    GNU General Public Licence (GPL) v2 http://www.gnu.org/
 #########################################################################
 # This program is free software; you can redistribute it and/or
@@ -17,7 +17,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
-#########################################################################
+# ########################################################################
 # Copyright (c) 2006 Aldo Fabi - First version (2006-09-01)
 # Copyright (c) 2013 Vitaliy Gladkevitch - Forked (2013-02-04)
 # Copyright (c) 2013-2023 Claudio Kuenzler - Current maintainer
@@ -25,6 +25,8 @@
 # Copyright (c) 2022 @waoki - Trap zpool command errors (2022-03-01)
 # Copyright (c) 2022 @mrdsam - Improvement (2022-05-24)
 # Copyright (c) 2023 @kresike - Improvement (2023-02-22)
+# Copyright (c) 2026 @joyfulrabbit - Improvement (2026-02-10)
+# Copyright (c) 2026 @numericillustration - Improvement (2026-02-11)
 #########################################################################
 # History/Changelog:
 # 2006-09-01  Original first version
@@ -43,131 +45,160 @@
 # 2023-02-15  Bugfix in single pool CRITICAL output (issue #13)
 # 2023-02-22  Improve message consistency and display all issues found in pool
 # 2023-09-28  Add license
+# 2026-02-10  Added check for spare disks in use
+# 2026-02-11  Fixed incongruous styles, enhanced exit checks, used vars, unified single and multiple pool checks
+#             removed unreachable code, consolidated on [[ and (( tests shellcheck error free
 #########################################################################
 ### Begin vars
 STATE_OK=0 # define the exit code if status is OK
 STATE_WARNING=1 # define the exit code if status is Warning
 STATE_CRITICAL=2 # define the exit code if status is Critical
 STATE_UNKNOWN=3 # define the exit code if status is Unknown
+declare -a POOLS
+declare -a error
+declare -a perfdata
 # Set path
-PATH=$PATH:/usr/sbin:/sbin
+PATH="${PATH}:/usr/sbin:/sbin"
 export PATH
 ### End vars
+
 #########################################################################
-help="check_zpools.sh (c) 2006-2023 multiple authors\n
+help="check_zpools.sh (c) 2006-2026 multiple authors\n
 Usage: $0 -p (poolname|ALL) [-w warnpercent] [-c critpercent]\n
 Example: $0 -p ALL -w 80 -c 90"
+
 #########################################################################
 # Check necessary commands are available
-for cmd in zpool [
-do
- if ! which "$cmd" 1>/dev/null
- then
- echo "UNKNOWN: ${cmd} does not exist, please check if command exists and PATH is correct"
- exit ${STATE_UNKNOWN}
- fi
-done
+if ! which zpool 1>/dev/null
+then
+    echo "UNKNOWN: zpool not found in path: $PATH, please check if command exists and PATH is correct"
+    exit "$STATE_UNKNOWN"
+fi
 #########################################################################
 # Check for people who need help - we are nice ;-)
-if [ "${1}" = "--help" ] || [ "${#}" = "0" ];
-       then
-       echo -e "${help}";
-       exit ${STATE_UNKNOWN};
+if [[ $1 = "--help" || "${#}" == "0" ]]
+then
+    echo -e "$help"
+    exit "$STATE_UNKNOWN"
 fi
 #########################################################################
 # Get user-given variables
 while getopts "p:w:c:" Input;
 do
-       case ${Input} in
-       p)      pool=${OPTARG};;
-       w)      warn=${OPTARG};;
-       c)      crit=${OPTARG};;
-       *)      echo -e "$help"
-               exit $STATE_UNKNOWN
-               ;;
-       esac
+    case "$Input" in
+    p)      pool="$OPTARG" ;;
+    w)      warn="$OPTARG" ;;
+    c)      crit="$OPTARG" ;;
+    *)      echo -e "$help"
+            exit "$STATE_UNKNOWN"
+            ;;
+    esac
 done
 #########################################################################
 # Did user obey to usage?
-if [ -z "$pool" ]; then echo -e "$help"; exit ${STATE_UNKNOWN}; fi
+if [[ -z "$pool" ]]
+then
+    echo -e "$help"
+    exit "$STATE_UNKNOWN"
+fi
+
 #########################################################################
-# Verify threshold sense
-if [[ -n $warn ]] && [[ -z $crit ]]; then echo "Both warning and critical thresholds must be set"; exit $STATE_UNKNOWN; fi
-if [[ -z $warn ]] && [[ -n $crit ]]; then echo "Both warning and critical thresholds must be set"; exit $STATE_UNKNOWN; fi
-if [[ $warn -gt $crit ]]; then echo "Warning threshold cannot be greater than critical"; exit $STATE_UNKNOWN; fi
+# Verify thresholds were supplied
+if [[ -z "$crit" || -z "$warn" ]]
+then
+    echo "Both warning and critical thresholds must be set"
+    exit "$STATE_UNKNOWN"
+fi
+
+if (( warn > crit ))
+then
+    echo "Warning threshold cannot be greater than critical"
+    exit "$STATE_UNKNOWN"
+fi
 #########################################################################
 # What needs to be checked?
 ## Check all pools
-if [ "$pool" = "ALL" ]
+if [[ $pool == "ALL" ]]
 then
-  POOLS=($(zpool list -Ho name))
-  if [ $? -ne 0 ]; then
-    echo "UNKNOWN zpool query failed"; exit $STATE_UNKNOWN
-  fi
-  p=0
-  for POOL in ${POOLS[*]}
-  do
-    CAPACITY=$(zpool list -Ho capacity "$POOL")
-    CAPACITY=${CAPACITY%\%}
-    HEALTH=$(zpool list -Ho health "$POOL")
-    if [ $? -ne 0 ]; then
-      echo "UNKNOWN zpool query failed"; exit $STATE_UNKNOWN
-    fi
-    # Check with thresholds
-    if [[ -n $warn ]] && [[ -n $crit ]]
+    mapfile -t POOLS <<<"$(zpool list -Ho name)"
+    pool_list_ret="$?"
+    if (( pool_list_ret > 0 ))
     then
-      if [ "$HEALTH" != "ONLINE" ]; then error[${p}]="$POOL health is $HEALTH // "; fcrit=1; fi
-      if [[ $CAPACITY -ge $crit ]]; then error[${p}]+="POOL $POOL usage is CRITICAL (${CAPACITY}%) // "; fcrit=1; fi
-      if [[ $CAPACITY -ge $warn && $CAPACITY -lt $crit ]]; then error[$p]+="POOL $POOL usage is WARNING (${CAPACITY}%)"; fi
-    # Check without thresholds
-    else
-      if [ "$HEALTH" != "ONLINE" ]
-      then error[${p}]="$POOL health is $HEALTH"; fcrit=1
-      fi
+        echo "UNKNOWN zpool list by name query failed"
+        exit "$STATE_UNKNOWN"
     fi
-    perfdata[$p]="$POOL=${CAPACITY}% "
-    let p++
-  done
-
-  if [[ ${#error[*]} -gt 0 ]]
-  then
-    if [[ $fcrit -eq 1 ]]; then exit_code=2; else exit_code=1; fi
-    echo "ZFS POOL ALARM: ${error[*]}|${perfdata[*]}"; exit ${exit_code}
-  else echo "ALL ZFS POOLS OK (${POOLS[*]})|${perfdata[*]}"; exit 0
-  fi
-
-## Check single pool
 else
-  CAPACITY=$(zpool list -Ho capacity "$pool" 2>&1 )
-  CAPACITY=${CAPACITY%\%}
-  if [[ -n $(echo "${CAPACITY}" | egrep -q 'no such pool$') ]]; then
-    echo "zpool $pool does not exist"; exit $STATE_CRITICAL
-  fi
-  HEALTH=$(zpool list -Ho health "$pool")
-  if [ $? -ne 0 ]; then
-    echo "UNKNOWN zpool query failed"; exit $STATE_UNKNOWN
-  fi
-
-  if [[ -n $warn ]] && [[ -n $crit ]]
-  then
-    warning=0
-    critical=0
-    # Check with thresholds
-    if [ "$HEALTH" != "ONLINE" ]; then error="$pool health is $HEALTH // "; critical=1 ; fi
-    if [[ $CAPACITY -ge $crit ]]; then error+="$pool usage is CRITICAL (${CAPACITY}%) // "; critical=1; fi
-    if [[ $CAPACITY -ge $warn && $CAPACITY -lt $crit ]]; then error+="ZFS POOL ALARM: $pool usage is WARNING (${CAPACITY}%) // "; warning=1; fi
-    if [[ $critical -gt 0 ]]; then echo "ZFS POOL ALARM: ${error[*]}|$pool=${CAPACITY}%"; exit ${STATE_CRITICAL}; fi
-    if [[ $warning -gt 0 ]]; then echo "ZFS POOL ALARM: ${error[*]}|$pool=${CAPACITY}%"; exit ${STATE_WARNING}; fi
-    echo "ALL ZFS POOLS OK ($pool)|$pool=${CAPACITY}%"; exit ${STATE_OK}
-  else
-    # Check without thresholds
-    if [ "$HEALTH" != "ONLINE" ]
-    then echo "ZFS POOL ALARM: $pool health is $HEALTH|$pool=${CAPACITY}%"; exit ${STATE_CRITICAL}
-    else echo "ALL ZFS POOLS OK ($pool)|$pool=${CAPACITY}%"; exit ${STATE_OK}
-    fi
-  fi
-
+    POOLS=( "$pool" )
 fi
 
-echo "UNKNOWN - Should never reach this part"
-exit ${STATE_UNKNOWN}
+for (( p=0; p<${#POOLS[@]}; p++))
+do
+    CAPACITY="$(zpool list -Ho capacity "${POOLS[$p]}" )"
+    cap_ret="$?"
+    if (( cap_ret > 0 ))
+    then
+        echo "UNKNOWN zpool query for capacity of ${POOLS[$p]} failed with exit code $cap_ret"
+        exit "$STATE_UNKNOWN"
+    fi
+
+    CAPACITY="${CAPACITY%\%}"
+
+    HEALTH="$(zpool list -Ho health "${POOLS[$p]}")"
+    health_ret="$?"
+    if (( health_ret > 0 ))
+    then
+        echo "UNKNOWN zpool query for health of ${POOLS[$p]} failed with exit code $health_ret"
+        exit "$STATE_UNKNOWN"
+    fi
+
+    # Check for spare disks in use (indicates a disk failure occurred sometime)
+    POOL_STATUS=$(zpool status "${POOLS[$p]}" )
+    status_ret="$?"
+    if (( status_ret > 0 ))
+    then
+        echo "UNKNOWN zpool query for status of ${POOLS[$p]} failed with exit code $status_ret"
+        exit "$STATE_UNKNOWN"
+    else
+        # grep the output now that the status command succeeded
+        SPARES_INUSE=$(grep -c "INUSE" <<<"$POOL_STATUS")
+    fi
+
+    # check if pool is healthy
+    if [[ $HEALTH != "ONLINE" ]]
+    then
+        error["$p"]="POOL ${POOLS[$p]} health is $HEALTH"
+        fcrit=1
+    fi
+
+    # Check that capacity is with thresholds
+    if (( CAPACITY > crit ))
+    then
+        error["$p"]+="POOL ${POOLS[$p]} usage is CRITICAL (${CAPACITY}%)"
+        fcrit=1
+    elif (( CAPACITY > warn )) && (( CAPACITY < crit ))
+    then
+        error["$p"]+="POOL ${POOLS[$p]} usage is WARNING (${CAPACITY}%)"
+    fi
+
+    # tell us whenever a spare is in use
+    if (( SPARES_INUSE > 0 ))
+    then
+        error["$p"]+="POOL ${POOLS[$p]} has $SPARES_INUSE spare(s) in use"
+    fi
+
+    perfdata["$p"]="${POOLS[$p]}=${CAPACITY}%"
+done
+
+if (( ${#error[*]} > 0 ))
+then
+    echo "ZFS POOL ALARM: ${error[*]}|${perfdata[*]}"
+    if (( fcrit == 1 ))
+    then
+        exit "$STATE_CRITICAL"
+    else
+        exit "$STATE_WARNING"
+    fi
+else
+    echo "ALL ZFS POOLS OK (${POOLS[*]})|${perfdata[*]}"
+    exit "$STATE_OK"
+fi

--- a/check_zpools.sh
+++ b/check_zpools.sh
@@ -17,7 +17,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
-# ########################################################################
+#########################################################################
 # Copyright (c) 2006 Aldo Fabi - First version (2006-09-01)
 # Copyright (c) 2013 Vitaliy Gladkevitch - Forked (2013-02-04)
 # Copyright (c) 2013-2023 Claudio Kuenzler - Current maintainer
@@ -76,7 +76,7 @@ then
 fi
 #########################################################################
 # Check for people who need help - we are nice ;-)
-if [[ $1 = "--help" || "${#}" == "0" ]]
+if [[ $1 == "--help" || "${#}" == "0" ]]
 then
     echo -e "$help"
     exit "$STATE_UNKNOWN"


### PR DESCRIPTION
We're using this check in our infra and found that there are times where a zpool with spares configured can have a disk go bad, be faulted from the pool, have a spare swap in, and then the system can reboot and the formerly bad disk is back to an ONLINE state resulting in not detecting this odd state.  I'm not sure if this is a particularity of zfs on Linux (proxmox system) or just that FMD on Solaris and SmartOS is better at re-ejecting bad disks after a reboot puts them back online.

Either way, I've rewritten this check to capture when a spare is in use and warn about it.

```
~$ zpool status
  pool: ams101-0415-h14-local-zpool
 state: ONLINE
status: One or more devices has experienced an unrecoverable error.  An
	attempt was made to correct the error.  Applications are unaffected.
action: Determine if the device needs to be replaced, and clear the errors
	using 'zpool clear' or replace the device with 'zpool replace'.
   see: https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-9P
  scan: scrub repaired 0B in 00:39:30 with 0 errors on Sun Feb  8 01:03:31 2026
config:

	NAME                          STATE     READ WRITE CKSUM
	ams101-0415-h14-local-zpool   ONLINE       0     0     0
	  mirror-0                    ONLINE       0     0     0
	    scsi-35000cca02d51e3e4    ONLINE       0     0     0
	    scsi-35000cca02d92cd98    ONLINE       0     0     0
	  mirror-1                    ONLINE       0     0     0
	    scsi-35000cca02d92f670    ONLINE       0     0     0
	    spare-1                   ONLINE       0     0     0
	      scsi-35000cca02d93050c  ONLINE       7     0    74
	      scsi-35000cca02d92fea4  ONLINE       0     0     0
	  mirror-2                    ONLINE       0     0     0
	    scsi-35000cca02d92f654    ONLINE       0     0     0
	    scsi-35000cca02d92cd8c    ONLINE       0     0     0
	  mirror-3                    ONLINE       0     0     0
	    scsi-35000cca0320c68ec    ONLINE       0     0     0
	    scsi-35000cca02d930404    ONLINE       0     0     0
	  mirror-4                    ONLINE       0     0     0
	    scsi-35000cca02d92f500    ONLINE       0     0     0
	    scsi-35000cca02d8f6a7c    ONLINE       0     0     0
	  mirror-5                    ONLINE       0     0     0
	    scsi-35000cca02d92dcc0    ONLINE       0     0     0
	    scsi-35000cca02d92e23c    ONLINE       0     0     0
	spares
	  scsi-35000cca02d92fea4      INUSE     currently in use

errors: No known data errors

  pool: rpool
 state: ONLINE
status: Some supported and requested features are not enabled on the pool.
	The pool can still be used, but some features are unavailable.
action: Enable all features using 'zpool upgrade'. Once this is done,
	the pool may no longer be accessible by software that does not support
	the features. See zpool-features(7) for details.
  scan: scrub repaired 0B in 00:03:01 with 0 errors on Sun Feb  8 00:27:03 2026
config:

	NAME                              STATE     READ WRITE CKSUM
	rpool                             ONLINE       0     0     0
	  mirror-0                        ONLINE       0     0     0
	    scsi-35000cca02d92e83c-part3  ONLINE       0     0     0
	    scsi-35000cca02d92e858-part3  ONLINE       0     0     0

errors: No known data errors
```


I've also streamlined the ALL and single pool options to use the same loop code by setting the array of pools to just the single user specified pool when not `ALL` to reduce having to update code in 2 places.

I've eliminated unreachable code paths and put into use the statically defined exit code variables at the top in all exits, where some of them were entirely unused before.

I've made all the intending consistent

I've made all the if then clauses indent the same way

I've eliminated unnecessary uses of  curly bracing around variables where it was not an array use or a method of differentiating a variable name from other characters not part of the name: `${variable}`

I've fixed any [shellcheck](https://github.com/koalaman/shellcheck) errors

Finally I also unified the code written by many authors over time using various tests to all use `[[` for string checks and `((` for numerical comparisons.



Testing output:

* `-p ALL -w 40 -c 30`
```
Warning threshold cannot be greater than critical
```


* `-p ALL -w 80 -c 90`
```
ALL ZFS POOLS OK (ams201-0308-h18-local-zpool rpool)|ams201-0308-h18-local-zpool=17% rpool=2%
```


* `-p ALL -w 2 -c 5` on a host with a spare in use and with a pool with more capacity filled than the crit threshold specified
```
ZFS POOL ALARM: POOL ams301-0212-h01-local-zpool usage is CRITICAL (11%)POOL ams301-0212-h01-local-zpool has 1 spare(s) in use|ams301-0212-h01-local-zpool=11% rpool=0%
```

*  `-p ams301-0212-h01-local-zpool -w 2 -c 5` checking same host specifying a single pool
```
ZFS POOL ALARM: POOL ams201-0308-h18-local-zpool usage is CRITICAL (17%) POOL rpool usage is WARNING (2%)|ams201-0308-h18-local-zpool=17% rpool=2%
```

* `-p rpool -w 2 -c 5` test on same host for other pool which is not higher than the crit rate
```
ALL ZFS POOLS OK (rpool)|rpool=0%
```


* `-p ALL -w 80 -c 90` on a system with one pool in DEGRADED state
```
ZFS POOL ALARM: POOL rpool health is DEGRADED|iad202-0205-h18-local-zpool=11% rpool=0%
```